### PR TITLE
cv32 integration

### DIFF
--- a/ips_list.yml
+++ b/ips_list.yml
@@ -76,8 +76,8 @@ ibex:
   group: lowRISC
   domain: [soc]
 cv32e40p:
-  commit: cv32e40p_v1.0.0
-  group: openhwgroup
+  commit: core-v-mcu
+  group: davideschiavone
   domain: [soc]
 scm:
   commit: v1.0.1

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -76,8 +76,8 @@ ibex:
   group: lowRISC
   domain: [soc]
 cv32e40p:
-  commit: core-v-mcu
-  group: davideschiavone
+  commit: ae5b08bc4cc3459748dfa809572e8107703a4ade
+  group: openhwgroup
   domain: [soc]
 scm:
   commit: v1.0.1

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -75,6 +75,10 @@ ibex:
   commit: e65a27e14dda7bb3b09cadc4e9232305fd451cec
   group: lowRISC
   domain: [soc]
+cv32e40p:
+  commit: cv32e40p_v1.0.0
+  group: openhwgroup
+  domain: [soc]
 scm:
   commit: v1.0.1
   domain: [cluster, soc]

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -10,18 +10,18 @@
 
 
 module fc_subsystem #(
-    parameter CORE_TYPE           = 0,
-    parameter USE_FPU             = 1,
-    parameter USE_HWPE            = 1,
-    parameter N_EXT_PERF_COUNTERS = 1,
-    parameter EVENT_ID_WIDTH      = 8,
-    parameter PER_ID_WIDTH        = 32,
-    parameter NB_HWPE_PORTS       = 4,
-    parameter PULP_SECURE         = 1,
-    parameter TB_RISCV            = 0,
-    parameter CORE_ID             = 4'h0,
-    parameter CLUSTER_ID          = 6'h1F,
-    parameter USE_ZFINX           = 1
+    parameter logic [1:0] CORE_TYPE = 0,
+    parameter USE_FPU               = 1,
+    parameter USE_HWPE              = 1,
+    parameter N_EXT_PERF_COUNTERS   = 1,
+    parameter EVENT_ID_WIDTH        = 8,
+    parameter PER_ID_WIDTH          = 32,
+    parameter NB_HWPE_PORTS         = 4,
+    parameter PULP_SECURE           = 1,
+    parameter TB_RISCV              = 0,
+    parameter CORE_ID               = 4'h0,
+    parameter CLUSTER_ID            = 6'h1F,
+    parameter USE_ZFINX             = 1
 )
 (
     input  logic                      clk_i,
@@ -54,7 +54,7 @@ module fc_subsystem #(
       cv32e40pCore    = 3
     } core_t;
 
-    localparam core_t CoreSelected = CORE_TYPE;
+    localparam core_t CoreSelected = core_t'(CORE_TYPE);
 
     localparam IBEX_RV32M = CoreSelected == IbexCoreRVIMC;
     localparam IBEX_RV32E = CoreSelected == IbexCoreRVEC;

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -125,7 +125,7 @@ module fc_subsystem #(
     //************ RISCV CORE ********************************
     //********************************************************
 
-    if ( CoreSelected == RiscyCore ) begin: gen_fc_core_riscy
+    if (CoreSelected == RiscyCore) begin: gen_fc_core_riscy
         // PULP RI5CY
         assign boot_addr = boot_addr_i;
         riscv_core #(
@@ -192,7 +192,7 @@ module fc_subsystem #(
             .ext_perf_counters_i   ( perf_counters_int ),
             .fregfile_disable_i    ( 1'b0              ) // try me!
         );
-    end else if( CoreSelected == cv32e40pCore ) begin: gen_fc_core_cv32e40p
+    end else if (CoreSelected == cv32e40pCore) begin: gen_fc_core_cv32e40p
          // OpenHW Group CV32E40P
          assign boot_addr = boot_addr_i;
          cv32e40p_wrapper #(
@@ -251,7 +251,7 @@ module fc_subsystem #(
              .core_sleep_o          (                   )
          );
 
-    end else if ( CoreSelected == IbexCoreRVEC || CoreSelected == IbexCoreRVIMC ) begin: gen_fc_core_ibex
+    end else if (CoreSelected == IbexCoreRVEC || CoreSelected == IbexCoreRVIMC) begin: gen_fc_core_ibex
     assign boot_addr = boot_addr_i & 32'hFFFFFF00; // RI5CY expects 0x80 offset, Ibex expects 0x00 offset (adds reset offset 0x80 internally)
 `ifdef VERILATOR
     ibex_core #(

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -183,7 +183,7 @@ module fc_subsystem #(
             .ext_perf_counters_i   ( perf_counters_int ),
             .fregfile_disable_i    ( 1'b0              ) // try me!
         );
-    end else if(CORE_TYPE == 4) begin: FC_CORE
+    end else if(CORE_TYPE == 3) begin: FC_CORE
          // OpenHW Group CV32E40P
          assign boot_addr = boot_addr_i;
          cv32e40p_wrapper #(

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -185,7 +185,10 @@ module fc_subsystem #(
         );
     end else if(CORE_TYPE == 4) begin: FC_CORE
          // OpenHW Group CV32E40P
-         cv32e40p_wrapper
+         assign boot_addr = boot_addr_i;
+         cv32e40p_wrapper #(
+            .PULP_XPULP (1)
+          )
           lFC_CORE (
              .clk_i                 ( clk_i             ),
              .rst_ni                ( rst_ni            ),

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -47,7 +47,6 @@ module fc_subsystem #(
     output logic                      supervisor_mode_o
 );
 
-    localparam USE_IBEX   = CORE_TYPE == 1 || CORE_TYPE == 2;
     localparam IBEX_RV32M = CORE_TYPE == 1;
     localparam IBEX_RV32E = CORE_TYPE == 2;
 
@@ -117,72 +116,129 @@ module fc_subsystem #(
     //************ RISCV CORE ********************************
     //********************************************************
     generate
-    if ( USE_IBEX == 0) begin: FC_CORE
-    assign boot_addr = boot_addr_i;
-    riscv_core #(
-        .N_EXT_PERF_COUNTERS ( N_EXT_PERF_COUNTERS ),
-        .PULP_SECURE         ( 1                   ),
-        .PULP_CLUSTER        ( 0                   ),
-        .FPU                 ( USE_FPU             ),
-        .FP_DIVSQRT          ( USE_FPU             ),
-        .SHARED_FP           ( 0                   ),
-        .SHARED_FP_DIVSQRT   ( 2                   ),
-        .Zfinx               ( USE_ZFINX           )
-    ) lFC_CORE (
-        .clk_i                 ( clk_i             ),
-        .rst_ni                ( rst_ni            ),
-        .clock_en_i            ( core_clock_en     ),
-        .test_en_i             ( test_en_i         ),
-        .boot_addr_i           ( boot_addr         ),
-        .core_id_i             ( CORE_ID           ),
-        .cluster_id_i          ( CLUSTER_ID        ),
+    if ( CORE_TYPE == 0) begin: FC_CORE
+        // PULP RI5CY
+        assign boot_addr = boot_addr_i;
+        riscv_core #(
+            .N_EXT_PERF_COUNTERS ( N_EXT_PERF_COUNTERS ),
+            .PULP_SECURE         ( 1                   ),
+            .PULP_CLUSTER        ( 0                   ),
+            .FPU                 ( USE_FPU             ),
+            .FP_DIVSQRT          ( USE_FPU             ),
+            .SHARED_FP           ( 0                   ),
+            .SHARED_FP_DIVSQRT   ( 2                   ),
+            .Zfinx               ( USE_ZFINX           )
+        ) lFC_CORE (
+            .clk_i                 ( clk_i             ),
+            .rst_ni                ( rst_ni            ),
+            .clock_en_i            ( core_clock_en     ),
+            .test_en_i             ( test_en_i         ),
+            .boot_addr_i           ( boot_addr         ),
+            .core_id_i             ( CORE_ID           ),
+            .cluster_id_i          ( CLUSTER_ID        ),
 
-        // Instruction Memory Interface:  Interface to Instruction Logaritmic interconnect: Req->grant handshake
-        .instr_addr_o          ( core_instr_addr   ),
-        .instr_req_o           ( core_instr_req    ),
-        .instr_rdata_i         ( core_instr_rdata  ),
-        .instr_gnt_i           ( core_instr_gnt    ),
-        .instr_rvalid_i        ( core_instr_rvalid ),
+            // Instruction Memory Interface:  Interface to Instruction Logaritmic interconnect: Req->grant handshake
+            .instr_addr_o          ( core_instr_addr   ),
+            .instr_req_o           ( core_instr_req    ),
+            .instr_rdata_i         ( core_instr_rdata  ),
+            .instr_gnt_i           ( core_instr_gnt    ),
+            .instr_rvalid_i        ( core_instr_rvalid ),
 
-        // Data memory interface:
-        .data_addr_o           ( core_data_addr    ),
-        .data_req_o            ( core_data_req     ),
-        .data_be_o             ( core_data_be      ),
-        .data_rdata_i          ( core_data_rdata   ),
-        .data_we_o             ( core_data_we      ),
-        .data_gnt_i            ( core_data_gnt     ),
-        .data_wdata_o          ( core_data_wdata   ),
-        .data_rvalid_i         ( core_data_rvalid  ),
+            // Data memory interface:
+            .data_addr_o           ( core_data_addr    ),
+            .data_req_o            ( core_data_req     ),
+            .data_be_o             ( core_data_be      ),
+            .data_rdata_i          ( core_data_rdata   ),
+            .data_we_o             ( core_data_we      ),
+            .data_gnt_i            ( core_data_gnt     ),
+            .data_wdata_o          ( core_data_wdata   ),
+            .data_rvalid_i         ( core_data_rvalid  ),
 
-        // apu-interconnect
-        // handshake signals
-        .apu_master_req_o      (                   ),
-        .apu_master_ready_o    (                   ),
-        .apu_master_gnt_i      ( 1'b1              ),
-        // request channel
-        .apu_master_operands_o (                   ),
-        .apu_master_op_o       (                   ),
-        .apu_master_type_o     (                   ),
-        .apu_master_flags_o    (                   ),
-        // response channel
-        .apu_master_valid_i    ( '0                ),
-        .apu_master_result_i   ( '0                ),
-        .apu_master_flags_i    ( '0                ),
+            // apu-interconnect
+            // handshake signals
+            .apu_master_req_o      (                   ),
+            .apu_master_ready_o    (                   ),
+            .apu_master_gnt_i      ( 1'b1              ),
+            // request channel
+            .apu_master_operands_o (                   ),
+            .apu_master_op_o       (                   ),
+            .apu_master_type_o     (                   ),
+            .apu_master_flags_o    (                   ),
+            // response channel
+            .apu_master_valid_i    ( '0                ),
+            .apu_master_result_i   ( '0                ),
+            .apu_master_flags_i    ( '0                ),
 
-        .irq_i                 ( core_irq_req      ),
-        .irq_id_i              ( core_irq_id       ),
-        .irq_ack_o             ( core_irq_ack      ),
-        .irq_id_o              ( core_irq_ack_id   ),
-        .irq_sec_i             ( 1'b0              ),
-        .sec_lvl_o             (                   ),
+            .irq_i                 ( core_irq_req      ),
+            .irq_id_i              ( core_irq_id       ),
+            .irq_ack_o             ( core_irq_ack      ),
+            .irq_id_o              ( core_irq_ack_id   ),
+            .irq_sec_i             ( 1'b0              ),
+            .sec_lvl_o             (                   ),
 
-        .debug_req_i           ( debug_req_i       ),
+            .debug_req_i           ( debug_req_i       ),
 
-        .fetch_enable_i        ( fetch_en_int      ),
-        .core_busy_o           (                   ),
-        .ext_perf_counters_i   ( perf_counters_int ),
-        .fregfile_disable_i    ( 1'b0              ) // try me!
-    );
+            .fetch_enable_i        ( fetch_en_int      ),
+            .core_busy_o           (                   ),
+            .ext_perf_counters_i   ( perf_counters_int ),
+            .fregfile_disable_i    ( 1'b0              ) // try me!
+        );
+    end else if(CORE_TYPE == 4) begin: FC_CORE
+         // OpenHW Group CV32E40P
+         cv32e40p_wrapper
+          lFC_CORE (
+             .clk_i                 ( clk_i             ),
+             .rst_ni                ( rst_ni            ),
+             .pulp_clock_en_i       ( core_clock_en     ),
+             .scan_cg_en_i          ( test_en_i         ),
+             .boot_addr_i           ( boot_addr         ),
+             .mtvec_addr_i          ( '0                ),
+             .dm_halt_addr_i        ( 32'h1A110800      ),
+             .hart_id_i             ( hart_id           ),
+             .dm_exception_addr_i   ( '0                ),
+
+             // Instruction Memory Interface
+             .instr_addr_o          ( core_instr_addr   ),
+             .instr_req_o           ( core_instr_req    ),
+             .instr_rdata_i         ( core_instr_rdata  ),
+             .instr_gnt_i           ( core_instr_gnt    ),
+             .instr_rvalid_i        ( core_instr_rvalid ),
+
+             // Data memory interface
+             .data_addr_o           ( core_data_addr    ),
+             .data_req_o            ( core_data_req     ),
+             .data_be_o             ( core_data_be      ),
+             .data_rdata_i          ( core_data_rdata   ),
+             .data_we_o             ( core_data_we      ),
+             .data_gnt_i            ( core_data_gnt     ),
+             .data_wdata_o          ( core_data_wdata   ),
+             .data_rvalid_i         ( core_data_rvalid  ),
+
+             // apu-interconnect
+             // handshake signals
+             .apu_req_o             (                   ),
+             .apu_gnt_i             ( 1'b1              ),
+             // request channel
+             .apu_operands_o        (                   ),
+             .apu_op_o              (                   ),
+             .apu_flags_o           (                   ),
+             // response channel
+             .apu_rvalid_i          ( '0                ),
+             .apu_result_i          ( '0                ),
+             .apu_flags_i           ( '0                ),
+
+             .irq_i                 ( core_irq_x        ),
+             .irq_ack_o             ( core_irq_ack      ),
+             .irq_id_o              ( core_irq_ack_id   ),
+
+             .debug_req_i           ( debug_req_i       ),
+             .debug_havereset_o     (                   ),
+             .debug_running_o       (                   ),
+             .debug_halted_o        (                   ),
+             .fetch_enable_i        ( fetch_en_int      ),
+             .core_sleep_o          (                   )
+         );
+
     end else begin: FC_CORE
     assign boot_addr = boot_addr_i & 32'hFFFFFF00; // RI5CY expects 0x80 offset, Ibex expects 0x00 offset (adds reset offset 0x80 internally)
 `ifdef VERILATOR
@@ -255,8 +311,8 @@ module fc_subsystem #(
     assign supervisor_mode_o = 1'b1;
 
     generate
-    if ( USE_IBEX == 1) begin : convert_irqs
-    // Ibex supports 32 additional fast interrupts and reads the interrupt lines directly.
+    if ( CORE_TYPE != 0) begin : convert_irqs
+    // Ibex and CV32E40P supports 32 additional fast interrupts and reads the interrupt lines directly.
     // Convert ID back to interrupt lines
     always_comb begin : gen_core_irq_x
         core_irq_x = '0;

--- a/rtl/fc/fc_subsystem.sv
+++ b/rtl/fc/fc_subsystem.sv
@@ -92,7 +92,7 @@ module fc_subsystem #(
     assign perf_counters_int = 1'b0;
     assign fetch_en_int      = fetch_en_eu & fetch_en_i;
 
-    assign hart_id = {21'b0, CLUSTER_ID[5:0], 1'b0, CORE_ID[3:0]};
+    assign hart_id = CoreSelected != cv32e40pCore ? {21'b0, CLUSTER_ID[5:0], 1'b0, CORE_ID[3:0]} : '0;
 
     XBAR_TCDM_BUS core_data_bus ();
     XBAR_TCDM_BUS core_instr_bus ();

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -244,7 +244,7 @@ module pulp_soc import dm::*; #(
 
     localparam ROM_ADDR_WIDTH        = 13;
 
-    localparam FC_CORE_CLUSTER_ID    = 6'd31;
+    localparam FC_CORE_CLUSTER_ID    = CORE_TYPE != 3 ? 6'd31 : 6'd0;
     localparam CL_CORE_CLUSTER_ID    = 6'd0;
 
     localparam FC_CORE_CORE_ID       = 4'd0;

--- a/rtl/pulp_soc/pulp_soc.sv
+++ b/rtl/pulp_soc/pulp_soc.sv
@@ -12,7 +12,7 @@
 `include "pulp_soc_defines.sv"
 
 module pulp_soc import dm::*; #(
-    parameter CORE_TYPE               = 0,
+    parameter logic [1:0] CORE_TYPE   = 0,
     parameter USE_FPU                 = 1,
     parameter USE_HWPE                = 1,
     parameter USE_CLUSTER_EVENT       = 1,


### PR DESCRIPTION
This commit adds:

* cv32e40p with XPULP extensions active to test its basic functionality with the pulp-runtime until freeRTOS is ready
* the cv32e40p reposiroty is taken from my GitHub until https://github.com/openhwgroup/cv32e40p/pull/610 gets merged

Once this PR is accepted, the core-v-mcu should be updated to always instantiate the cv32e40p core wi the CORE_TYPE parameter